### PR TITLE
Enable auto-merge for Dependabot PRs via GitHub Actions

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,22 @@
+name: Auto Merge Dependabot PRs
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - opened
+      - synchronize
+    branches:
+      - development
+
+jobs:
+  automerge:
+    if: |
+      github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge for Dependabot PR
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash


### PR DESCRIPTION
Create a new GitHub Actions workflow to automatically merge Dependabot pull requests when they are labeled, opened, or synchronized on the development branch.